### PR TITLE
Add April committee minutes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ _site
 .sass-cache
 Gemfile.lock
 .swp
+*~
 .jekyll-metadata

--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,12 @@ markdown: kramdown
 # To explore for the future
 #plugins:
 #  - jekyll-redirect-from
+
+defaults:
+  - scope:
+      path: "_posts/minutes"
+      type: "posts"
+    values:
+      category: "minutes"
+      layout: "page"
+      permalink: "/events/committee/:year/:month-:day/"

--- a/_posts/minutes/2019-04-16-minutes.md
+++ b/_posts/minutes/2019-04-16-minutes.md
@@ -1,0 +1,201 @@
+---
+title: PLUG Meeting Minutes 2019-04-16
+---
+
+# PLUG Meeting Minutes 2019-04-16
+
+If anyone wants to add any items, please do so the day before
+
+## 0. Opening
+Meeting opened by Benjamin at 7:40 PM.
+
+Attendance
+Present: Benjamin, Nick, James, Peter
+Apologies: Margaret, Paul, Michel
+Absent: x
+
+## 1. Confirmation of Previous Minutes.
+MOTION: Proposed by Benjamin and Seconded by James. Passed? Yes.
+https://docs.google.com/document/d/1XrLvyw5P3shgLbFrcOKC5AFe5fmyahF0ChZWLX_9wWY
+
+## 2. Reports & Standing Items.
+* Financial Situation as of 2019-04-15 (Peter)
+  * Cash box 
+    * $369.35 current, $252.55 start of year    ($252.55 start 2018)
+  * Debit card(old)
+    * $40.86 current, $40.86 start of year    ($40.86  start 2018)
+  * Load&Go(new)
+    * $35.45 current, $27.89 start of year    ($161.21 start 2018)
+  * Bank Balance
+    * $2536.79 current, $2850.34 start of year    ($3469.95 start 2018)
+  * Total Moneys
+    * $2982.45 (was $3309.34 start of year)    ($3924.57 start 2018)
+  * Income
+    * $0.00 this month,    $70.00 last, $155.00 this year
+  * Expense
+    * $72.66 this month,    $102.85 last, $435.89 this year
+  * Profit(Loss)
+    * $(72.66) this month,    (32.85) last, (280.89) this year.
+
+  * Outstanding Payment Claims:
+    * $8.28    owing to Margaret    for Food at Monthly Meeting
+    Unbanked Receipts:
+    * $20 donations at 2019-04-09 meeting
+
+-Moved to new business-
+
+* Membership Situation as of 2019-04-16 (Paul)
+  *	0 renewals/new in April $0
+  * 1 renewals/new in March $20
+  * 3 renewals/new in February $40
+  * 1 renewals/new in January $20
+  * 26 Current Paid Members, previous month was 26
+  * 296 Expired Members, previous month was 296
+  * 359 Members on meetup.com, previous month 347
+  * 854 Visitors on meetup.com in April (as of today 16/04) 2019
+  * 1933 Visitors on meetup.com in March (*revised since last meeting) 2019
+  * 1060 Visitors on meetup.com in February 2019
+  * 619 Visitors on meetup.com in January 2019
+
+## 3. Events:
+
+Paul: Meeting and Google calendar is updated.
+
+* March 2019. 
+  * 2019-03-12 James Henstridge - Ubuntu Core.
+  * Any feedback for James Henstridge’s talk?
+    * It was about 19 people attending which is very good for the start of the year.
+    Paul: I emailed Amandine about the room temperature and space problem.
+    Sounds on AV will have to be sorted for next time, instead of camera mic.
+    AV prep: thank you Paddy and Laz!
+  * 2019-03-25 PLUG-in-the-Pub: Durty Nellie’s, CBD.
+    * Feedback? (NB thought it was great, JH says it was fine)
+
+* April 2019.
+  * Second Sunday Regular PLUG + POSH Hack Day
+  * 2019-04-09 Greg Orange - Open Summit.
+    * Feedback? Get slides?
+
+* May 2019.
+  * Second Sunday Regular PLUG + POSH Hack Day
+  * **2019-05-14: Raspberry Pi Jam/demos?** Michel Officeworks email to follow up.
+    * Also bring your laptop/games?
+    * TODO: Ben to follow up?
+    * NB says promote it, make it biggest event of the year, get sponsorship if possible
+        * BA to purchase a raspberry pi kit to bring
+        * Bring network switches, need an Access Point
+        * BA to purchase 4 microSD (as they need spares) preloaded with noobs
+        * Encourage others to bring their own Raspberry Pis
+        * Perhaps a prize of a Pi?
+    * $100 budget for food and drink?
+        * Get Subway, order platters at least 2 days before event.
+        * ACTION: Peter to order 2019-05-12
+        * ACTION: Someone to pick it up on the day
+        * ACTION: Nick: NAT wifi AP
+        * ACTION: Nick: Pimoroni radio to autoconnect
+        * ACTION: Nick: 2x monitor+keyboard
+
+  * ACTION: Planning & promotion.
+  * Quartermaster for this specific event
+  * At least once a week until this event, all PLUG committee to drum up discussion on the lists
+
+  * **2019-05-27?: PLUG-in-the-pub** - location?
+    * ACTION: South? Nick to research [Last Drop Beeliar](https://www.lastdropbeeliarpubandbrewery.com.au/)?
+
+* June 2019.
+  * Second Sunday Regular PLUG + POSH Hack Day
+  * 2019-06-11 Benjamin's Linux & Open Source LAN Party
+      * Need list of games, will have HDD with copies of games?
+      * List of games needed? Sauerbraten, Nexuiz, 0 A.D., Fractured Space? Tuxracer/kart/Supertux, BZflag
+      * Steam games for Linux?
+          * Keep Talking and Nobody Explodes?
+          * Jackbox games?
+
+* July 2019.
+  * Second Sunday Regular PLUG + POSH Hack Day
+  * Talk by Benjamin on MooseFS + The Elastic NAS
+  * 2019-07-22 PLUG in the Pub
+  * If nothing leave for next meeting.
+
+* August/September 2019.
+  * Benjamin to talk to Martin Dougiamas
+  * Installfest? USB drives?
+  * 2019-09-23 PLUG-in-the-Pub @ Pirate Bar
+
+## 4. General Business and Matters Arising.
+Constitution changes. Peter got an email from the Government saying our Special Resolution application has been received and is being reviewed.
+
+P.O. Box has expired, we chose not to renew it.
+* ACTION (urgent): Update PLUG addresses:
+  TO: PLUG Treasurer/President as appropriate (President: Unit 410/130A Mounts Bay Road) (Treasurer: X)
+  Paul to call Bendigobank.com.au
+  DMIRS.wa.gov.au / Dept of Commerce
+  acnc.gov.au
+  Margaret will check ASIC.gov.au
+  Paul to follow up ato.gov.au
+* nginx + Apache2 site configs for UGMM
+  PLUG Incorporation number: A1007186U
+  PLUG ABN: 58 233 849 580
+  PLUG’s IANA PEN: 37966
+  
+Interest bearing accounts. Someone to follow up?
+  Still TODO
+  * Interest bearing accounts:
+    https://www.communitysectorbanking.com.au/banking/social-investment-deposit-account 1.4%pa
+    https://www.communitysectorbanking.com.au/banking/term-deposit
+    UBank term deposit, min $1000
+
+Sponsorship Agreement. Paul: I have called and emailed Committee /Amandine 
+from Spacecubed and waiting on reply.
+
+ACTION: Peter 2018/2019 financial report on website .ODP
+Stil TODO? Follow up next meeting
+
+--end of old business, new business below--
+
+## 5. New General Business.
+Tender for UGMM work was accepted, awaiting invoice from Alastair.
+
+If we receive $150 invoice, pay it immediately? (Agreed as part of tender)
+Original RFT2019-01 tender:
+https://docs.google.com/document/d/1B-YIsCShAmE6GRC8DXavo6-UtSbZTOROL1NBeSzHlk8/edit
+
+MOTION: Proposed by Benjamin. Seconded by James. Extend a work order to Alastair for $100 inc. GST to cover the 3 tasks listed below:
+* Fix all errors/warnings
+* Integrate handy LDAP testing scripts/data
+* Make nginx + Apache2 site configs and make them optional dependencies for the package.
+
+Work order would be contingent on testing on PLUG's test server + acceptance of pull request.
+
+Peter abstains, Nick abstains
+Benjamin votes for, James votes for
+
+Motion passed. (Benjamin has offered to cover the cost of the work order in the event that the motion is later rescinded.)
+
+ACTION: JamesH, Benjamin & Nick to merge the final pull request/comments
+
+Work continues on PLUG Services migration - Mail only main remaining piece other than UGMM. Mail still a big job.
+
+AWS credits - purchase them off eBay at a discount
+
+HackMD, does it suck?
+* Makes it possible to put minutes on the website immediately
+* James likes it
+* Benjamin loves it
+* Nick likes it, but self-hosting it as codimd - even better
+* Can upload old minutes via pandoc (to HTML or Markdown)
+* Ben proposes using HackMD (or CodiMD) until decided otherwise. Seconded by James
+* Peter: So far so good but would like to think about it.
+
+MOTION: Add $150 to PLUG Load&Go card
+Proposed: Peter Seconded: Benjamin
+Passed without dissent.
+
+Nick reminds us to check in visibly on the mailing lists at least every 7 days until JAM. Let's make it a great one.
+
+## 6. Next committee meeting
+Tuesday 2019-05-21
+
+---
+
+Meeting closed by Benjamin at 9:00 PM.

--- a/pages/events/committee.md
+++ b/pages/events/committee.md
@@ -24,8 +24,8 @@ Minutes for the Perth Linux User Group AGMs:
 
 Minutes for PLUG committee meetings:
 
-{% for post in site.posts %}
-{% if post.categories contains "minutes" %}
+{% for post in site.posts -%}
+{% if post.categories contains "minutes" -%}
 * [{{ post.title }}]({{ post.url }})
-{% endif %}
+{% endif -%}
 {% endfor %}

--- a/pages/events/committee.md
+++ b/pages/events/committee.md
@@ -22,3 +22,10 @@ Minutes for the Perth Linux User Group AGMs:
 * [2003]({{ site.baseurl }}/events/AGM/2003)
 * [2002]({{ site.baseurl }}/events/AGM/2002)
 
+Minutes for PLUG committee meetings:
+
+{% for post in site.posts %}
+{% if post.categories contains "minutes" %}
+* [{{ post.title }}]({{ post.url }})
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
By placing minutes in ./_posts/minutes, they will be given an
appropriate permalink, and automatically added to the committee index
page.